### PR TITLE
Adjust UI mode and action parameter handling

### DIFF
--- a/src/main/java/com/example/demo/controller/ShiftEditController.java
+++ b/src/main/java/com/example/demo/controller/ShiftEditController.java
@@ -3,7 +3,7 @@ package com.example.demo.controller;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam; // ← 追加：mode 受け取り用
+import org.springframework.web.bind.annotation.RequestParam; // ← 追加：action 受け取り用
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import com.example.demo.form.ShiftGenerationForm;
@@ -23,7 +23,7 @@ import com.example.demo.service.ShiftService;
  * 保存処理が完了したら PRG パターンで再度 /shift/generate にリダイレクトする。
  *
  * ▼変更点
- * ・フロント側のボタンはすべて /api/shift/request/save にPOSTし、name="mode"の値で分岐
+ * ・フロント側のボタンはすべて /api/shift/request/save にPOSTし、name="action" の値で分岐
  * ・本クラスのルートも /api/shift/request に変更
  */
 @Controller
@@ -38,23 +38,23 @@ public class ShiftEditController {
 
     /**
      * 共通保存エンドポイント
-     * - mode=DRAFT      : 一時保存（下書き）
-     * - mode=CONFIRMED  : 確定保存
-     * - mode=UNCONFIRM  : 確定解除（確定→下書きに戻す）
+     * - action=DRAFT      : 一時保存（下書き）
+     * - action=CONFIRMED  : 確定保存
+     * - action=UNCONFIRM  : 確定解除（確定→下書きに戻す）
      *
      * 例）generate.html のボタン：
-     *  <button type="submit" formaction="/api/shift/request/save" name="mode" value="DRAFT">一時保存</button>
+     *  <button type="submit" formaction="/api/shift/request/save" name="action" value="DRAFT">一時保存</button>
      */
     @PostMapping("/save")
     public String save(ShiftGenerationForm form,
-                       @RequestParam(name = "mode", defaultValue = "CONFIRMED") String mode,
+                       @RequestParam(name = "action", defaultValue = "CONFIRMED") String action,
                        RedirectAttributes ra) {
 
-        // mode の大小文字・余白を吸収
-        final String m = mode == null ? "CONFIRMED" : mode.trim().toUpperCase();
+        // action の大小文字・余白を吸収
+        final String normalizedAction = action == null ? "CONFIRMED" : action.trim().toUpperCase();
 
         String notice;
-        switch (m) {
+        switch (normalizedAction) {
         case "DRAFT":
             // ▼ 下書き保存
             shiftService.saveShifts(form, Shift.Status.DRAFT);
@@ -74,7 +74,7 @@ public class ShiftEditController {
             break;
 
         default:
-            // ▼ 想定外モードは CONFIRMED と同等で扱う
+            // ▼ 想定外アクションは CONFIRMED と同等で扱う
             shiftService.saveShifts(form, Shift.Status.CONFIRMED);
             notice = "シフトを確定しました。";
             break;

--- a/src/main/resources/templates/shift/generate.html
+++ b/src/main/resources/templates/shift/generate.html
@@ -79,7 +79,7 @@
   <a th:href="@{/shift/edit(department=${department}, month=${month})}">シフト編集</a>
 </form>
 
-<!-- ▼ モード切替（フロントのみ。POST時は hiddenのmodeで受け取れる） -->
+<!-- ▼ モード切替（フロントのみ。POST時は hidden の uiMode で受け取れる） -->
 <div class="panel">
   <strong>入力モード</strong>：
   <button type="button" onclick="setMode('normal')">通常</button>
@@ -124,7 +124,7 @@
   <!-- 画面状態の保持 -->
   <input type="hidden" name="department" th:value="${department != null ? department : ''}">
   <input type="hidden" name="month"      th:value="${month != null ? month : ''}">
-  <input type="hidden" id="mode" name="mode" value="normal">
+  <input type="hidden" id="uiMode" name="uiMode" value="normal">
   
   <!-- shiftMap が空なら初期状態の案内を表示 -->
   <div class="panel" style="background:#f1f8e9;"
@@ -234,7 +234,7 @@
     <button type="submit"
             th:formaction="@{/api/shift/request/save}"
             formmethod="post"
-            name="mode" value="DRAFT">
+            name="action" value="DRAFT">
       一時保存
     </button>
 
@@ -242,7 +242,7 @@
     <button type="submit"
             th:formaction="@{/api/shift/request/save}"
             formmethod="post"
-            name="mode" value="CONFIRMED">
+            name="action" value="CONFIRMED">
       確定（生成に反映）
     </button>
 
@@ -250,7 +250,7 @@
     <button type="submit"
             th:formaction="@{/api/shift/request/save}"
             formmethod="post"
-            name="mode" value="UNCONFIRM">
+            name="action" value="UNCONFIRM">
       確定解除
     </button>
 
@@ -283,16 +283,16 @@
   const cycleTemp    = ['臨(確)','-'];
 
   function currentCycle(){
-    // hidden の mode を参照して、サイクルを切り替える
-    const m = document.getElementById('mode').value;
+    // hidden の uiMode を参照して、サイクルを切り替える
+    const m = document.getElementById('uiMode').value;
     if(m === 'request') return cycleRequest;
     if(m === 'temp')    return cycleTemp;
     return cycleNormal;
   }
 
   function setMode(m){
-    // 画面表示のみ切替（POST時は hidden の mode でサーバへ渡る）
-    document.getElementById('mode').value = m;
+    // 画面表示のみ切替（POST時は hidden の uiMode でサーバへ渡る）
+    document.getElementById('uiMode').value = m;
   }
 
   // ▼ 共通：セルへ値を適用（ペイント／サイクルの両方から呼び出す）


### PR DESCRIPTION
## Summary
- rename the generate view's hidden UI mode field to `uiMode` and update front-end logic to use the new identifier
- change the form submit buttons to post their intent through the `action` parameter
- update `ShiftEditController` to read the new `action` request parameter and refresh related documentation comments

## Testing
- sh ./gradlew test *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c8fb60030083278680c87222bf9c35