### PR TITLE
Fix target month binding in shift generation form

### DIFF
--- a/src/main/resources/templates/shift/generate.html
+++ b/src/main/resources/templates/shift/generate.html
@@ -122,8 +122,8 @@
   <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}"/>
 
   <!-- 画面状態の保持 -->
-  <input type="hidden" name="department" th:value="${department != null ? department : ''}">
-  <input type="hidden" name="month"      th:value="${month != null ? month : ''}">
+  <input type="hidden" name="department"  th:value="${department != null ? department : ''}">
+  <input type="hidden" name="targetMonth" th:value="${month != null ? month : ''}">
   <input type="hidden" id="mode" name="mode" value="normal">
   
   <!-- shiftMap が空なら初期状態の案内を表示 -->


### PR DESCRIPTION
## Summary
- rename the hidden field in the shift generation template to `targetMonth` so the binder populates `ShiftGenerationForm`
- confirm the redirect logic can read `form.getTargetMonth()` after submission

## Testing
- sh gradlew test *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c8fb60998c83279129f713389c8759