### PR TITLE
Rename hidden target month field in generate template

### DIFF
--- a/src/main/resources/templates/shift/generate.html
+++ b/src/main/resources/templates/shift/generate.html
@@ -123,7 +123,7 @@
 
   <!-- 画面状態の保持 -->
   <input type="hidden" name="department" th:value="${department != null ? department : ''}">
-  <input type="hidden" name="month"      th:value="${month != null ? month : ''}">
+  <input type="hidden" name="targetMonth"      th:value="${month != null ? month : ''}">
   <input type="hidden" id="uiMode" name="uiMode" value="normal">
   
   <!-- shiftMap が空なら初期状態の案内を表示 -->


### PR DESCRIPTION
## Summary
- rename the hidden month input field to targetMonth so redirects keep the selected month while retaining the existing value binding

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c967a89ebc8327aab6d3b51abcce10