### PR TITLE
Annotate target month with DateTimeFormat

### DIFF
--- a/src/main/java/com/example/demo/form/ShiftGenerationForm.java
+++ b/src/main/java/com/example/demo/form/ShiftGenerationForm.java
@@ -4,6 +4,8 @@ import java.time.YearMonth;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.format.annotation.DateTimeFormat;
+
 /**
  * シフト生成画面から送信されるフォームオブジェクト。
  * 希望休・臨時職員・シフト入力をまとめて受け取る。
@@ -17,6 +19,7 @@ public class ShiftGenerationForm {
     private List<TemporaryAssignmentForm> temporaryAssignments;
 
     // シフト生成対象の月
+    @DateTimeFormat(pattern = "yyyy-MM")
     private YearMonth targetMonth;
 
     // 所属部署（例: "amami", "main"）


### PR DESCRIPTION
## Summary
- annotate the shift generation form's target month with `@DateTimeFormat` so `yyyy-MM` request parameters bind correctly
- add the `DateTimeFormat` import required for the annotation

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68ca1c60b37c83279ae291033f2af253