### PR TITLE
Ensure saved shift types render in generate and list views

### DIFF
--- a/src/main/java/com/example/demo/service/ShiftService.java
+++ b/src/main/java/com/example/demo/service/ShiftService.java
@@ -62,8 +62,15 @@ public class ShiftService {
         for (Shift shift : shifts) {
             Long userId = shift.getUser().getId();
             LocalDate date = shift.getDate();
+            String shiftType = shift.getShiftType();
+
+            if (!StringUtils.hasText(shiftType)) {
+                // 空文字や null は画面に表示しない（既存の値を上書きしない）
+                continue;
+            }
+
             String key = userId + "_" + date;
-            map.put(key, shift.getShiftType());
+            map.put(key, shiftType.trim());
         }
 
         return map;

--- a/src/main/resources/templates/shift/generate.html
+++ b/src/main/resources/templates/shift/generate.html
@@ -167,23 +167,25 @@
 
         <!-- セル：shiftMap が null でも落ちないように th:with で val を取得し三項でガード -->
         <td th:each="d : ${dates != null ? dates : {}}"
-            th:with="key=${user.id + '_' + d}, val=${shiftMap != null ? shiftMap[key] : null}"
-            th:classappend="${val != null ? val : ''}">
+            th:with="dateKey=${#temporals.format(d, 'yyyy-MM-dd')},
+                     key=${user.id + '_' + dateKey},
+                     val=${shiftMap != null ? #strings.trim(shiftMap[key]) : null}"
+            th:classappend="${!#strings.isEmpty(val) ? val : ''}">
           
           <!-- ▼ 追加：属性保持（onclickは削除） -->
           <button
             type="button"
             class="cell-btn"
-            th:id="${'btn_' + user.id + '_' + d}"
+            th:id="${'btn_' + user.id + '_' + dateKey}"
             th:data-user-id="${user.id}"
-            th:data-date="${d}"
-            th:text="${val != null ? val : '-'}">
+            th:data-date="${dateKey}"
+            th:text="${!#strings.isEmpty(val) ? val : '-'}">
           </button>
 
           <!-- 送信用 hidden（nameは userId_date で一意）。null の場合は空文字で送る -->
           <input type="hidden"
-                 th:id="${'val_' + user.id + '_' + d}"
-                 th:name="${'shifts[' + user.id + '_' + d + ']'}"
+                 th:id="${'val_' + user.id + '_' + dateKey}"
+                 th:name="|shifts['${user.id}_${dateKey}']|"
                  th:value="${val != null ? val : ''}">
         </td>
       </tr>

--- a/src/main/resources/templates/shift/list.html
+++ b/src/main/resources/templates/shift/list.html
@@ -46,9 +46,11 @@
         <tr th:each="user : ${users}">
             <td th:text="${user.lastName + ' ' + user.firstName}"></td>
             <td th:each="d : ${dates}"
-                th:with="key=${user.id + '_' + d}"
-                th:text="${shiftMap[key]}"
-                th:class="${shiftMap[key]}" />
+                th:with="dateKey=${#temporals.format(d, 'yyyy-MM-dd')},
+                         key=${user.id + '_' + dateKey},
+                         val=${shiftMap != null ? #strings.trim(shiftMap[key]) : null}"
+                th:text="${!#strings.isEmpty(val) ? val : '-'}"
+                th:classappend="${!#strings.isEmpty(val) ? val : ''}"></td>
         </tr>
     </tbody>
 </table>


### PR DESCRIPTION
## Summary
- ignore blank shift types when building the map returned to the shift screens so existing values are not overwritten
- normalize date keys in the generate and list templates and display trimmed shift values with a fallback marker

## Testing
- ./gradlew test *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68ca54f6fc648327abd32b4cbda21640